### PR TITLE
Fix for jx kh crds

### DIFF
--- a/.lighthouse/jenkins-x/pullrequest.yaml
+++ b/.lighthouse/jenkins-x/pullrequest.yaml
@@ -12,15 +12,16 @@ spec:
         stepTemplate:
           image: uses:jenkins-x/jx3-pipeline-catalog/tasks/go-plugin/pullrequest.yaml@versionStream
           resources:
-            requests:
-              cpu: 400m
-              memory: 600Mi
+            limits: {}
           workingDir: /workspace/source
         steps:
         - image: uses:jenkins-x/jx3-pipeline-catalog/tasks/git-clone/git-clone-pr.yaml@versionStream
           name: ""
         - name: jx-variables
-          resources: {}
+          resources:
+            requests:
+              cpu: 400m
+              memory: 600Mi
         - image: golang:1.15
           name: build-make-linux
           resources: {}

--- a/charts/jx-kh-check/templates/example-check.yaml
+++ b/charts/jx-kh-check/templates/example-check.yaml
@@ -9,6 +9,7 @@ spec:
   runInterval: {{ .Values.example.runInterval }}
   timeout: {{ .Values.example.timeout }}
   podSpec:
+    restartPolicy: Never
     containers:
       - name: example
         image: {{ .Values.example.image.repository }}:{{ .Values.image.tag }}
@@ -24,7 +25,6 @@ spec:
             memory: 15Mi
           limits:
             cpu: 40m
-        restartPolicy: Never
     serviceAccountName: example-sa
     terminationGracePeriodSeconds: 60
 ---

--- a/charts/jx-kh-check/templates/jx-bot-token.yaml
+++ b/charts/jx-kh-check/templates/jx-bot-token.yaml
@@ -11,6 +11,7 @@ spec:
   runInterval: {{ .Values.jxBotToken.runInterval }}
   timeout: {{ .Values.jxBotToken.timeout }}
   podSpec:
+    restartPolicy: Never  
     containers:
       - name: jx-bot-token
         image: {{ .Values.jxBotToken.image.repository }}:{{ .Values.image.tag }}
@@ -19,8 +20,7 @@ spec:
             cpu: 25m
             memory: 15Mi
           limits:
-            cpu: 40m
-        restartPolicy: Never
+            cpu: 100m
         env:
         - name: OAUTH_TOKEN
           valueFrom:

--- a/charts/jx-kh-check/templates/jx-install-check.yaml
+++ b/charts/jx-kh-check/templates/jx-install-check.yaml
@@ -11,6 +11,7 @@ spec:
   runInterval: {{ .Values.jxInstall.runInterval }}
   timeout: {{ .Values.jxInstall.timeout }}
   podSpec:
+    restartPolicy: Never  
     containers:
       - name: jx-install
         image: {{ .Values.jxInstall.image.repository }}:{{ .Values.image.tag }}
@@ -19,8 +20,7 @@ spec:
             cpu: 25m
             memory: 15Mi
           limits:
-            cpu: 40m
-        restartPolicy: Never
+            cpu: 100m
     serviceAccountName: jx-install-sa
     terminationGracePeriodSeconds: 60
 ---

--- a/charts/jx-kh-check/templates/jx-webhook-check.yaml
+++ b/charts/jx-kh-check/templates/jx-webhook-check.yaml
@@ -11,6 +11,7 @@ spec:
   runInterval: {{ .Values.jxWebhooks.runInterval }}
   timeout: {{ .Values.jxWebhooks.timeout }}
   podSpec:
+    restartPolicy: Never    
     containers:
       - name: jx-webhook
         image: {{ .Values.jxWebhooks.image.repository }}:{{ .Values.image.tag }}
@@ -19,8 +20,7 @@ spec:
             cpu: 25m
             memory: 15Mi
           limits:
-            cpu: 40m
-        restartPolicy: Never
+            cpu: 100m
     serviceAccountName: jx-webhook-sa
     terminationGracePeriodSeconds: 60
 ---

--- a/charts/jx-kh-check/templates/jx-webhook-events-check.yaml
+++ b/charts/jx-kh-check/templates/jx-webhook-events-check.yaml
@@ -11,6 +11,7 @@ spec:
   runInterval: {{ .Values.jxWebhookEvents.runInterval }}
   timeout: {{ .Values.jxWebhookEvents.timeout }}
   podSpec:
+    restartPolicy: Never
     containers:
       - name: jx-webhook-events
         image: {{ .Values.jxWebhookEvents.image.repository }}:{{ .Values.image.tag }}
@@ -19,8 +20,7 @@ spec:
             cpu: 25m
             memory: 15Mi
           limits:
-            cpu: 40m
-        restartPolicy: Never
+            cpu: 100m
     serviceAccountName: jx-webhook-events-sa
     terminationGracePeriodSeconds: 60
 ---


### PR DESCRIPTION
The current healthcheck jobs for jx don't match the latest specification from kuberhealthy CRDs

The field restarPolicy was moved from `io.github.comcast.v1.KuberhealthyCheck.spec.podSpec.containers` to `io.github.comcast.v1.KuberhealthyCheck.spec.podSpec` as specified [here](https://github.com/kuberhealthy/kuberhealthy/blob/master/deploy/helm/kuberhealthy/crds/comcast.github.io_khchecks.yaml)

That was causing the deployment of current charts to fail with the following errors:

```
error validating "config-root/namespaces/jx/jx-kh-check-health-checks-jx/jx-bot-token-kuberhealthycheck.yaml": error validating data: ValidationError(KuberhealthyCheck.spec.podSpec.containers[0]): unknown field "restartPolicy" in io.github.comcast.v1.KuberhealthyCheck.spec.podSpec.containers; if you choose to ignore these errors, turn validation off with --validate=false
error validating "config-root/namespaces/jx/jx-kh-check-health-checks-jx/jx-webhook-events-kuberhealthycheck.yaml": error validating data: ValidationError(KuberhealthyCheck.spec.podSpec.containers[0]): unknown field "restartPolicy" in io.github.comcast.v1.KuberhealthyCheck.spec.podSpec.containers; if you choose to ignore these errors, turn validation off with --validate=false
error validating "config-root/namespaces/jx/jx-kh-check-health-checks-jx/jx-webhook-kuberhealthycheck.yaml": error validating data: ValidationError(KuberhealthyCheck.spec.podSpec.containers[0]): unknown field "restartPolicy" in io.github.comcast.v1.KuberhealthyCheck.spec.podSpec.containers; if you choose to ignore these errors, turn validation off with --validate=false
```
Changes on the commits of this PR solve this. Also I raise a little bit the resource limits of the containers.